### PR TITLE
Fixed moduletype message parsing for old modules

### DIFF
--- a/velbus/messages/module_type.py
+++ b/velbus/messages/module_type.py
@@ -7,14 +7,14 @@ from velbus.command_registry import register_command
 from velbus.module_registry import MODULE_DIRECTORY
 
 COMMAND_CODE = 0xff
-
 MODULES_WITHOUT_SERIAL = {
+    0x01: 'VMB8PB',
+    0x02: 'VMB1RY',
+    0x03: 'VMB1BL',
+    0x05: 'VMB6IN',
+    0x07: 'VMB1DM',
     0x08: 'VMB4RY',
-    0x14: 'VMBDME',
-}
-
-MODULES_WITHOUT_MEMORY_MAP = {
-    0x08: 'VMB4RY',
+    0x09: 'VMB2BL',
     0x14: 'VMBDME',
 }
 
@@ -58,7 +58,6 @@ class ModuleTypeMessage(Message):
         if data[0] not in MODULES_WITHOUT_SERIAL:
             (self.serial,) = struct.unpack(
                 '>L', bytes([0, 0, data[1], data[2]]))
-        if data[0] not in MODULES_WITHOUT_MEMORY_MAP:
             self.memory_map_version = data[3]
         self.build_year = data[-2]
         self.build_week = data[-1]

--- a/velbus/messages/module_type.py
+++ b/velbus/messages/module_type.py
@@ -8,6 +8,16 @@ from velbus.module_registry import MODULE_DIRECTORY
 
 COMMAND_CODE = 0xff
 
+MODULES_WITHOUT_SERIAL = {
+    0x08: 'VMB4RY',
+    0x14: 'VMBDME',
+}
+
+MODULES_WITHOUT_MEMORY_MAP = {
+    0x08: 'VMB4RY',
+    0x14: 'VMBDME',
+}
+
 class ModuleTypeMessage(Message):
     """
     send by: VMB6IN, VMB4RYLD
@@ -45,12 +55,13 @@ class ModuleTypeMessage(Message):
         self.needs_data(data, 4)
         self.set_attributes(priority, address, rtr)
         self.module_type = data[0]
-        (self.serial,) = struct.unpack(
-            '>L', bytes([0, 0, data[1], data[2]]))
-        self.memory_map_version = data[3]
-        if len(data) > 4:
-            self.build_year = data[4]
-            self.build_week = data[5]
+        if data[0] not in MODULES_WITHOUT_SERIAL:
+            (self.serial,) = struct.unpack(
+                '>L', bytes([0, 0, data[1], data[2]]))
+        if data[0] not in MODULES_WITHOUT_MEMORY_MAP:
+            self.memory_map_version = data[3]
+        self.build_year = data[-2]
+        self.build_week = data[-1]
 
     def data_to_binary(self):
         """


### PR DESCRIPTION
Some older modules don't expose a serial number or memory map in the module type message.
As result these properties were populated with a wrong (mostly identical) value. Because the HomeAssistant integration assign unique ID's based on the serialnumber value a second module of the same type don't get an unique ID and wil be missing from detection.
This PR wil solve this.