### PR TITLE
Make LED buttons controllable

### DIFF
--- a/velbus/messages/clear_led.py
+++ b/velbus/messages/clear_led.py
@@ -14,7 +14,7 @@ class ClearLedMessage(Message):
 
     def __init__(self, address=None):
         Message.__init__(self)
-        self.clear_leds = []
+        self.leds = []
         self.set_defaults(address)
 
     def populate(self, priority, address, rtr, data):
@@ -26,13 +26,13 @@ class ClearLedMessage(Message):
         self.needs_no_rtr(rtr)
         self.needs_data(data, 1)
         self.set_attributes(priority, address, rtr)
-        self.clear_leds = self.byte_to_channels(data[0])
+        self.leds = self.byte_to_channels(data[0])
 
     def data_to_binary(self):
         """
         :return: bytes
         """
-        return bytes([COMMAND_CODE, self.channels_to_byte(self.clear_leds)])
+        return bytes([COMMAND_CODE, self.channels_to_byte(self.leds)])
 
 
 register_command(COMMAND_CODE, ClearLedMessage)

--- a/velbus/modules/vmb4dc.py
+++ b/velbus/modules/vmb4dc.py
@@ -104,5 +104,8 @@ class VMB4DCModule(Module):
     def get_categories(self, channel):
         return ['light']
 
+    def light_is_buttonled(self, channel):
+        return False
+
 
 register_module('VMB4DC', VMB4DCModule)

--- a/velbus/modules/vmbdme.py
+++ b/velbus/modules/vmbdme.py
@@ -104,5 +104,8 @@ class VMBDMEModule(Module):
     def get_categories(self, channel):
         return ['light']
 
+    def light_is_buttonled(self, channel):
+        return False
+
 
 register_module('VMBDME', VMBDMEModule)

--- a/velbus/modules/vmbgp.py
+++ b/velbus/modules/vmbgp.py
@@ -12,6 +12,11 @@ from velbus.messages.switch_to_night import SwitchToNightMessage
 from velbus.messages.switch_to_day import SwitchToDayMessage
 from velbus.messages.switch_to_comfort import SwitchToComfortMessage
 from velbus.messages.set_temperature import SetTemperatureMessage
+from velbus.messages.update_led_status import UpdateLedStatusMessage
+from velbus.messages.set_led import SetLedMessage
+from velbus.messages.slow_blinking_led import SlowBlinkingLedMessage
+from velbus.messages.fast_blinking_led import FastBlinkingLedMessage
+from velbus.messages.clear_led import ClearLedMessage
 
 class VMBGPxModule(Module):
     """
@@ -22,6 +27,7 @@ class VMBGPxModule(Module):
         Module.__init__(self, module_type, module_name, module_address, controller)
         self._is_closed = {}
         self._is_enabled = {}
+        self._led_state = {}
         self._cur = None
         self._min = None
         self._max = None
@@ -82,6 +88,87 @@ class VMBGPxModule(Module):
                 if channel in self._callbacks:
                     for callback in self._callbacks[channel]:
                         callback(self._is_closed[channel])
+        elif isinstance(message, UpdateLedStatusMessage):
+            for channel in list(range(1, self._controllable_channels + 1)):
+                self._led_state[channel] = "off"
+                if channel in message.led_slow_blinking:
+                    self._led_state[channel] = "slow"
+                if channel in message.led_fast_blinking:
+                    self._led_state[channel] = "fast"
+                if channel in message.led_on:
+                    self._led_state[channel] = "on"
+                if channel in self._led_state and channel in self._callbacks:
+                    for callback in self._callbacks[channel]:
+                        callback(self._led_state[channel])
+        elif isinstance(message, SetLedMessage):
+            for channel in list(range(1, self._controllable_channels + 1)):
+                if channel in message.leds:
+                    self._led_state[channel] = "on"
+                if channel in self._led_state and channel in self._callbacks:
+                    for callback in self._callbacks[channel]:
+                        callback(self._led_state[channel])
+        elif isinstance(message, ClearLedMessage):
+            for channel in list(range(1, self._controllable_channels + 1)):
+                if channel in message.leds:
+                    self._led_state[channel] = "off"
+                if channel in self._led_state and channel in self._callbacks:
+                    for callback in self._callbacks[channel]:
+                        callback(self._led_state[channel])
+        elif isinstance(message, SlowBlinkingLedMessage):
+            for channel in list(range(1, self._controllable_channels + 1)):
+                if channel in message.leds:
+                    self._led_state[channel] = "slow"
+                if channel in self._led_state and channel in self._callbacks:
+                    for callback in self._callbacks[channel]:
+                        callback(self._led_state[channel])
+        elif isinstance(message, FastBlinkingLedMessage):
+            for channel in list(range(1, self._controllable_channels + 1)):
+                if channel in message.leds:
+                    self._led_state[channel] = "fast"
+                if channel in self._led_state and channel in self._callbacks:
+                    for callback in self._callbacks[channel]:
+                        callback(self._led_state[channel])
+
+    def is_on(self, channel):
+        """
+        Check if led of channel is turned on
+
+        :return: bool
+        """
+        if channel in self._led_state:
+            if self._led_state[channel] == "off":
+                return False
+            else:
+                return True
+        return False
+
+    def set_led_state(self, channel, state, callback=None):
+        """
+        Set led
+
+        :return: None
+        """
+        if callback is None:
+            def callb():
+                """No-op"""
+                pass
+            callback = callb
+        if state == "on":
+            message = SetLedMessage(self._address)
+        elif state == "slow":
+            message = SlowBlinkingLedMessage(self._address)
+        elif state == "fast":
+            message = FastBlinkingLedMessage(self._address)
+        elif state == "off":
+            message = ClearLedMessage(self._address)
+        else:
+            return
+        message.leds = [channel]
+        self._led_state[channel] = state
+        self._controller.send(message, callback)
+
+    def light_is_buttonled(self, channel):
+        return True
 
     def on_status_update(self, channel, callback):
         """
@@ -95,7 +182,7 @@ class VMBGPxModule(Module):
         if channel == 33:
             return ['sensor']
         elif channel in self._is_enabled and self._is_enabled[channel]:
-            return ['binary_sensor']
+            return ['binary_sensor', 'light']
         else:
             return []
 
@@ -121,69 +208,24 @@ class VMBGPxModule(Module):
         return '°C'
 
 
-class VMBGPxSubModule(Module):
+class VMBGPxSubModule(VMBGPxModule):
     """
     Velbus input sub module with 8 input channels
     """
 
     def __init__(self, module_type, module_name, module_address,
                  master_address, sub_module, controller):
-        Module.__init__(self, module_type, module_name, module_address,
+        VMBGPxModule.__init__(self, module_type, module_name, module_address,
                         controller)
-        self._is_closed = {}
-        self._is_enabled = {}
-        self._callbacks = {}
         self._master_address = master_address
         self.sub_module = sub_module
 
     def _is_submodule(self):
         return True
 
-    def is_closed(self, channel):
-        if channel in self._is_closed:
-            return self._is_closed[channel]
-        return False
-
-    def is_enabled(self, channel):
-        if channel in self._is_enabled:
-            return self._is_enabled[channel]
-        return False
-
-    def _on_message(self, message):
-        if isinstance(message, PushButtonStatusMessage):
-            for channel in message.closed:
-                self._is_closed[channel] = True
-            for channel in message.opened:
-                self._is_closed[channel] = False
-            for channel in message.get_channels():
-                if channel in self._callbacks:
-                    for callback in self._callbacks[channel]:
-                        callback(self._is_closed[channel])
-        elif isinstance(message, ModuleStatusMessage2):
-            for channel in list(range(1, self.number_of_channels() + 1)):
-                if channel in message.closed:
-                    self._is_closed[channel] = True
-                else:
-                    self._is_closed[channel] = False
-                if channel in message.enabled:
-                    self._is_enabled[channel] = True
-                else:
-                    self._is_enabled[channel] = False
-                if channel in self._callbacks:
-                    for callback in self._callbacks[channel]:
-                        callback(self._is_closed[channel])
-
-    def on_status_update(self, channel, callback):
-        """
-        Callback to execute on status of update of channel
-        """
-        if channel not in self._callbacks:
-            self._callbacks[channel] = []
-        self._callbacks[channel].append(callback)
-
     def get_categories(self, channel):
         if channel in self._is_enabled and self._is_enabled[channel]:
-            return ['binary_sensor']
+            return ['binary_sensor', 'light']
         else:
             return []
 

--- a/velbus/modules/vmbpbn.py
+++ b/velbus/modules/vmbpbn.py
@@ -5,6 +5,11 @@ from velbus.module import Module
 from velbus.module_registry import register_module
 from velbus.messages.push_button_status import PushButtonStatusMessage
 from velbus.messages.module_status import ModuleStatusMessage2
+from velbus.messages.update_led_status import UpdateLedStatusMessage
+from velbus.messages.set_led import SetLedMessage
+from velbus.messages.slow_blinking_led import SlowBlinkingLedMessage
+from velbus.messages.fast_blinking_led import FastBlinkingLedMessage
+from velbus.messages.clear_led import ClearLedMessage
 
 
 class VMB2PBNModule(Module):
@@ -16,6 +21,7 @@ class VMB2PBNModule(Module):
         self._is_closed = {}
         self._is_enabled = {}
         self._callbacks = {}
+        self._led_state = {}
 
     def is_closed(self, channel):
         if channel in self._is_closed:
@@ -45,6 +51,87 @@ class VMB2PBNModule(Module):
                     self._is_enabled[channel] = True
                 else:
                     self._is_enabled[channel] = False
+        elif isinstance(message, UpdateLedStatusMessage):
+            for channel in list(range(1, self.number_of_channels()+ 1)):
+                self._led_state[channel] = "off"
+                if channel in message.led_slow_blinking:
+                    self._led_state[channel] = "slow"
+                if channel in message.led_fast_blinking:
+                    self._led_state[channel] = "fast"
+                if channel in message.led_on:
+                    self._led_state[channel] = "on"
+                if channel in self._led_state and channel in self._callbacks:
+                    for callback in self._callbacks[channel]:
+                        callback(self._led_state[channel])
+        elif isinstance(message, SetLedMessage):
+            for channel in list(range(1, self.number_of_channels()+ 1)):
+                if channel in message.leds:
+                    self._led_state[channel] = "on"
+                if channel in self._led_state and channel in self._callbacks:
+                    for callback in self._callbacks[channel]:
+                        callback(self._led_state[channel])
+        elif isinstance(message, ClearLedMessage):
+            for channel in list(range(1, self.number_of_channels()+ 1)):
+                if channel in message.leds:
+                    self._led_state[channel] = "off"
+                if channel in self._led_state and channel in self._callbacks:
+                    for callback in self._callbacks[channel]:
+                        callback(self._led_state[channel])
+        elif isinstance(message, SlowBlinkingLedMessage):
+            for channel in list(range(1, self.number_of_channels()+ 1)):
+                if channel in message.leds:
+                    self._led_state[channel] = "slow"
+                if channel in self._led_state and channel in self._callbacks:
+                    for callback in self._callbacks[channel]:
+                        callback(self._led_state[channel])
+        elif isinstance(message, FastBlinkingLedMessage):
+            for channel in list(range(1, self.number_of_channels()+ 1)):
+                if channel in message.leds:
+                    self._led_state[channel] = "fast"
+                if channel in self._led_state and channel in self._callbacks:
+                    for callback in self._callbacks[channel]:
+                        callback(self._led_state[channel])
+
+    def is_on(self, channel):
+        """
+        Check if led of channel is turned on
+
+        :return: bool
+        """
+        if channel in self._led_state:
+            if self._led_state[channel] == "off":
+                return False
+            else:
+                return True
+        return False
+
+    def set_led_state(self, channel, state, callback=None):
+        """
+        Set led
+
+        :return: None
+        """
+        if callback is None:
+            def callb():
+                """No-op"""
+                pass
+            callback = callb
+        if state == "on":
+            message = SetLedMessage(self._address)
+        elif state == "slow":
+            message = SlowBlinkingLedMessage(self._address)
+        elif state == "fast":
+            message = FastBlinkingLedMessage(self._address)
+        elif state == "off":
+            message = ClearLedMessage(self._address)
+        else:
+            return
+        message.leds = [channel]
+        self._led_state[channel] = state
+        self._controller.send(message, callback)
+
+    def light_is_buttonled(self, channel):
+        return True
 
     def on_status_update(self, channel, callback):
         """
@@ -56,7 +143,7 @@ class VMB2PBNModule(Module):
 
     def get_categories(self, channel):
         if channel in self._is_enabled and self._is_enabled[channel]:
-            return ['binary_sensor']
+            return ['binary_sensor', 'light']]
         else:
             return []
 

--- a/velbus/modules/vmbpbn.py
+++ b/velbus/modules/vmbpbn.py
@@ -143,7 +143,7 @@ class VMB2PBNModule(Module):
 
     def get_categories(self, channel):
         if channel in self._is_enabled and self._is_enabled[channel]:
-            return ['binary_sensor', 'light']]
+            return ['binary_sensor', 'light']
         else:
             return []
 

--- a/velbus/modules/vmbpbn.py
+++ b/velbus/modules/vmbpbn.py
@@ -52,7 +52,7 @@ class VMB2PBNModule(Module):
                 else:
                     self._is_enabled[channel] = False
         elif isinstance(message, UpdateLedStatusMessage):
-            for channel in list(range(1, self.number_of_channels()+ 1)):
+            for channel in list(range(1, self.number_of_channels() + 1)):
                 self._led_state[channel] = "off"
                 if channel in message.led_slow_blinking:
                     self._led_state[channel] = "slow"
@@ -64,28 +64,28 @@ class VMB2PBNModule(Module):
                     for callback in self._callbacks[channel]:
                         callback(self._led_state[channel])
         elif isinstance(message, SetLedMessage):
-            for channel in list(range(1, self.number_of_channels()+ 1)):
+            for channel in list(range(1, self.number_of_channels() + 1)):
                 if channel in message.leds:
                     self._led_state[channel] = "on"
                 if channel in self._led_state and channel in self._callbacks:
                     for callback in self._callbacks[channel]:
                         callback(self._led_state[channel])
         elif isinstance(message, ClearLedMessage):
-            for channel in list(range(1, self.number_of_channels()+ 1)):
+            for channel in list(range(1, self.number_of_channels() + 1)):
                 if channel in message.leds:
                     self._led_state[channel] = "off"
                 if channel in self._led_state and channel in self._callbacks:
                     for callback in self._callbacks[channel]:
                         callback(self._led_state[channel])
         elif isinstance(message, SlowBlinkingLedMessage):
-            for channel in list(range(1, self.number_of_channels()+ 1)):
+            for channel in list(range(1, self.number_of_channels() + 1)):
                 if channel in message.leds:
                     self._led_state[channel] = "slow"
                 if channel in self._led_state and channel in self._callbacks:
                     for callback in self._callbacks[channel]:
                         callback(self._led_state[channel])
         elif isinstance(message, FastBlinkingLedMessage):
-            for channel in list(range(1, self.number_of_channels()+ 1)):
+            for channel in list(range(1, self.number_of_channels() + 1)):
                 if channel in message.leds:
                     self._led_state[channel] = "fast"
                 if channel in self._led_state and channel in self._callbacks:


### PR DESCRIPTION
This PR makes the LED's of buttons controllable so it possible to “link” a button to an external device (I.e. when using Home Assistant linking to an entity could be done with some smart automation rules) and allow the LED to indicates if the external device is actually on / off.

I've added `light_is_buttonled()` to allow distinction between regular controllable lights and LEDs of the buttons. This allows the Home Assistant integration to default mark all LEDs as _disabled_ "light" entities so only the usable LED's can be manually enabled.