### PR TITLE
Validate transition time as Int

### DIFF
--- a/velbus/modules/vmb4dc.py
+++ b/velbus/modules/vmb4dc.py
@@ -61,7 +61,7 @@ class VMB4DCModule(Module):
         message = SetDimmerMessage(self._address)
         message.dimmer_channels = [channel]
         message.dimmer_state = slider
-        message.dimmer_transitiontime = transitiontime
+        message.dimmer_transitiontime = int(transitiontime)
         self._dimmer_state[channel] = slider
         self._controller.send(message, callback)
 
@@ -78,7 +78,7 @@ class VMB4DCModule(Module):
             callback = callb
         message = RestoreDimmerMessage(self._address)
         message.dimmer_channels = [channel]
-        message.dimmer_transitiontime = transitiontime
+        message.dimmer_transitiontime = int(transitiontime)
         self._controller.send(message, callback)
 
     def _on_message(self, message):

--- a/velbus/modules/vmbdme.py
+++ b/velbus/modules/vmbdme.py
@@ -61,7 +61,7 @@ class VMBDMEModule(Module):
         message = SetDimmerMessage(self._address)
         message.dimmer_channels = [channel]
         message.dimmer_state = slider
-        message.dimmer_transitiontime = transitiontime
+        message.dimmer_transitiontime = int(transitiontime)
         self._controller.send(message, callback)
 
     def restore_dimmer_state(
@@ -78,7 +78,7 @@ class VMBDMEModule(Module):
             callback = callb
         message = RestoreDimmerMessage(self._address)
         message.dimmer_channels = [channel]
-        message.dimmer_transitiontime = transitiontime
+        message.dimmer_transitiontime = int(transitiontime)
         self._controller.send(message, callback)
 
     def _on_message(self, message):


### PR DESCRIPTION
Make sure transition time is an integer in case a floating nummer is supplied (like HASS does).
When a floating nummer supplied the serial interface fails to send the message and makes the lib losing the connection.