### PR TITLE
Add support for memo text messages

### DIFF
--- a/velbus/messages/__init__.py
+++ b/velbus/messages/__init__.py
@@ -65,3 +65,4 @@ from velbus.messages.dimmer_status import DimmerStatusMessage
 from velbus.messages.set_dimmer import SetDimmerMessage
 from velbus.messages.restore_dimmer import RestoreDimmerMessage
 from velbus.messages.slider_status import SliderStatusMessage
+from velbus.messages.memo_text import MemoTextMessage

--- a/velbus/messages/memo_text.py
+++ b/velbus/messages/memo_text.py
@@ -1,0 +1,44 @@
+"""
+:author: Maikel Punie <maikel.punie@gmail.com>
+"""
+import json
+from velbus.message import Message
+from velbus.command_registry import register_command
+
+COMMAND_CODE = 0xAC
+
+
+class MemoTextMessage(Message):
+    """
+    send by:
+    received by: VMBGPO, VMBGPOD
+    """
+
+    def __init__(self, address=None):
+        Message.__init__(self)
+        self.start = 0x00
+        self.memo_text = ""
+        self.set_defaults(address)
+
+    def populate(self, priority, address, rtr, data):
+        """
+        :return: None
+        """
+        assert isinstance(data, bytes)
+        self.needs_low_priority(priority)
+        self.needs_no_rtr(rtr)
+        self.needs_data(data, 7)
+        self.set_attributes(priority, address, rtr)
+        self.start = data[1]
+        self.name = "".join([chr(x) for x in data[2:]])
+
+    def data_to_binary(self):
+        """
+        :return: bytes
+        """
+        while len(self.memo_text) < 5:
+            self.memo_text += chr(0)
+        return bytes([COMMAND_CODE, 0x00, self.start]) + bytes(self.memo_text, 'utf-8')
+
+
+register_command(COMMAND_CODE, MemoTextMessage)

--- a/velbus/messages/memo_text.py
+++ b/velbus/messages/memo_text.py
@@ -1,7 +1,6 @@
 """
 :author: Maikel Punie <maikel.punie@gmail.com>
 """
-import json
 from velbus.message import Message
 from velbus.command_registry import register_command
 
@@ -38,7 +37,10 @@ class MemoTextMessage(Message):
         """
         while len(self.memo_text) < 5:
             self.memo_text += chr(0)
-        return bytes([COMMAND_CODE, 0x00, self.start]) + bytes(self.memo_text, 'utf-8')
-
+        return bytes([
+            COMMAND_CODE,
+            0x00,
+            self.start
+            ]) + bytes(self.memo_text, 'utf-8')
 
 register_command(COMMAND_CODE, MemoTextMessage)

--- a/velbus/messages/memo_text.py
+++ b/velbus/messages/memo_text.py
@@ -37,10 +37,9 @@ class MemoTextMessage(Message):
         """
         while len(self.memo_text) < 5:
             self.memo_text += chr(0)
-        return bytes([
-            COMMAND_CODE,
-            0x00,
-            self.start
-            ]) + bytes(self.memo_text, 'utf-8')
+        return bytes([COMMAND_CODE, 0x00, self.start]) + bytes(
+            self.memo_text, 'utf-8'
+        )
+
 
 register_command(COMMAND_CODE, MemoTextMessage)

--- a/velbus/modules/vmbgp.py
+++ b/velbus/modules/vmbgp.py
@@ -17,6 +17,7 @@ from velbus.messages.set_led import SetLedMessage
 from velbus.messages.slow_blinking_led import SlowBlinkingLedMessage
 from velbus.messages.fast_blinking_led import FastBlinkingLedMessage
 from velbus.messages.clear_led import ClearLedMessage
+from velbus.messages.memo_text import MemoTextMessage
 
 
 class VMBGPxModule(Module):
@@ -211,6 +212,23 @@ class VMBGPxModule(Module):
         """
         return '°C'
 
+    def set_memo_text(self, text_message=""):
+        """
+        set the memo text
+        Empty message clears memo
+        """
+        assert isinstance(text_message, str)
+        assert len(text_message) <= 64
+        message = MemoTextMessage(self._address)
+        msgcntr = 0
+        for char in text_message:
+            message.memo_text += char
+            if len(message.memo_text) >= 5:
+                msgcntr += 5
+                self._controller.send(message)
+                message = MemoTextMessage(self._address)
+                message.start = msgcntr
+        self._controller.send(message)
 
 class VMBGPxSubModule(VMBGPxModule):
     """


### PR DESCRIPTION
Add support to send memo text messages to be shown at VMBGPO,  VMBGPOD & VMBELO modules.

This [commit](https://github.com/brefra/home-assistant/commit/5655e4be6c1a5de17bc1b0fb0cd784108c301a90) at my fork of Home Assistant make this feature accessible by an custom service.