### PR TITLE
Dynamic load timeout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="python-velbus",
-    version="2.1.3",
+    version="2.1.4",
     url="https://github.com/thomasdelaet/python-velbus",
     license="MIT",
     author="Thomas Delaet",

--- a/velbus/controller.py
+++ b/velbus/controller.py
@@ -175,6 +175,7 @@ class Controller(object):
             self.load_timeout = threading.Timer(_timeout + 1, timeout_expired).start()
             for module in self._modules:
                 self._modules[module].load(module_loaded)
+                time.sleep(1)  # Throttle loading modules
 
         for address in range(0, 256):
             message = ModuleTypeRequestMessage(address)

--- a/velbus/controller.py
+++ b/velbus/controller.py
@@ -191,7 +191,7 @@ class Controller(object):
                         (_missing_modules * 10) + 1, final_timeout_expired
                     ).start()
 
-            # Set first timeout (10 second for each module to load) to trigger a retry
+            # Set first timeout to 10 second for each module to trigger a retry
             threading.Timer((len(self._modules) * 10) + 1, first_retry).start()
 
             for module in self._modules:

--- a/velbus/controller.py
+++ b/velbus/controller.py
@@ -170,8 +170,9 @@ class Controller(object):
                         del self._modules[module]
                     callback()
 
-            # 180 second timeout for loading modules
-            self.load_timeout = threading.Timer(360, timeout_expired).start()
+            # 10 second timeout for each module to load
+            _timeout = len(self._modules) * 10
+            self.load_timeout = threading.Timer(_timeout + 1, timeout_expired).start()
             for module in self._modules:
                 self._modules[module].load(module_loaded)
 

--- a/velbus/module.py
+++ b/velbus/module.py
@@ -1,10 +1,10 @@
 """
 :author: Thomas Delaet <thomas@delaet.org>
 """
-import datetime
 import string
 import struct
 from velbus.messages.read_data_from_memory import ReadDataFromMemoryMessage
+from datetime import datetime, timedelta
 from velbus.messages.memory_data import MemoryDataMessage
 from velbus.messages.channel_name_part1 import ChannelNamePart1Message
 from velbus.messages.channel_name_part1 import ChannelNamePart1Message2
@@ -42,7 +42,7 @@ class Module(object):
         self.loaded = False
         self._loading_triggered = False
 
-        self._last_channel_name_msg = datetime.datetime.utcnow()
+        self._last_channel_name_msg = datetime.utcnow()
         self._controller = controller
         self._controller.subscribe(self.on_message)
 
@@ -170,7 +170,7 @@ class Module(object):
                     not self._is_submodule()
                     and not self._name_messages_complete()
                     and self._last_channel_name_msg
-                    < datetime.datetime.utcnow() - datetime.timedelta(seconds=10)
+                    < datetime.utcnow() - timedelta(seconds=10)
                 ):
                     self._request_channel_name()
             if callback:
@@ -203,7 +203,7 @@ class Module(object):
         return self.number_of_channels() * 3
 
     def _process_channel_name_message(self, part, message):
-        self._last_channel_name_msg = datetime.datetime.utcnow()
+        self._last_channel_name_msg = datetime.utcnow()
         channel = message.channel
         if self._is_submodule():
             channel = channel - (self.number_of_channels() * self.sub_module)

--- a/velbus/module.py
+++ b/velbus/module.py
@@ -39,7 +39,7 @@ class Module(object):
 
         self._loaded_callbacks = []
         self.loaded = False
-        self._load_in_progress = False
+        self._loading_triggered = False
 
         self._controller = controller
         self._controller.subscribe(self.on_message)
@@ -150,8 +150,8 @@ class Module(object):
         Retrieve names of channels
         """
         if not self.loaded:
-            if not self._load_in_progress:
-                self._load_in_progress = True
+            if not self._loading_triggered:
+                self._loading_triggered = True
                 if not self._is_submodule():
                     # load the data from memory ( the stuff that we need)
                     self._load_memory()

--- a/velbus/module.py
+++ b/velbus/module.py
@@ -39,6 +39,7 @@ class Module(object):
 
         self._loaded_callbacks = []
         self.loaded = False
+        self._load_in_progress = False
 
         self._controller = controller
         self._controller.subscribe(self.on_message)
@@ -148,18 +149,24 @@ class Module(object):
         """
         Retrieve names of channels
         """
-        if not self._is_submodule():
-            # load the data from memory ( the stuff that we need)
-            self._load_memory()
-        # load the module status
-        self._request_module_status()
-        if not self._is_submodule():
-            # load the channel names
-            self._request_channel_name()
-        if callback:
-            self._loaded_callbacks.append(callback)
-        # load the module specific stuff
-        self._load()
+        if not self.loaded:
+            if not self._load_in_progress:
+                self._load_in_progress = True
+                if not self._is_submodule():
+                    # load the data from memory ( the stuff that we need)
+                    self._load_memory()
+                # load the module status
+                self._request_module_status()
+                if not self._is_submodule():
+                    # load the channel names
+                    self._request_channel_name()
+                # load the module specific stuff
+                self._load()
+            if callback:
+                self._loaded_callbacks.append(callback)
+        else:
+            if callback:
+                callback()
 
     def loading_in_progress(self):
         return not self._name_messages_complete()


### PR DESCRIPTION
Based on log supplied at #76

- Make the discovery timeout dynamically based on the number of modules. So a small setup has has short time out and a large setup with many modules takes long timeout.
- Added an extra 1 second delay between every module load to allow some time to processing.
- Add second try to load modules by requesting channel names again if it failed the first time.

PR still draft, as I'm currently still testing the code changes

